### PR TITLE
Feature/deletar pacote por

### DIFF
--- a/frontend/Entregou/src/app/services/database.service.ts
+++ b/frontend/Entregou/src/app/services/database.service.ts
@@ -64,6 +64,12 @@ export class DatabaseService {
     return this.http.get<any[]>(`${this.apiUrl}/pacotes/meusPacotes`, { headers });
   }
 
+  apagarPacote(id: number): Observable<any> {
+    const token = localStorage.getItem('token');
+    const headers = { 'Authorization': `Bearer ${token}` };
+    return this.http.delete(`${this.apiUrl}/pacotes/${id}`, { headers });
+  }
+
   buscarUsuarios(termo: string): Observable<UsuarioAutoComplete[]> {
     const token = localStorage.getItem('token');
     const headers = { 'Authorization': `Bearer ${token}` };

--- a/frontend/Entregou/src/app/user-dashboard/listar-pacote/listar-pacote.component.html
+++ b/frontend/Entregou/src/app/user-dashboard/listar-pacote/listar-pacote.component.html
@@ -2,11 +2,11 @@
     <div class="header">
         <h1>Lista de Pacotes</h1>
         <p>Todos os seus pacotes estão listados aqui.</p>
-        
-        <button 
-            mat-raised-button 
-            color="primary" 
-            (click)="recarregar()" 
+
+        <button
+            mat-raised-button
+            color="primary"
+            (click)="recarregar()"
             [disabled]="loading"
             class="reload-btn">
             <mat-icon>refresh</mat-icon>
@@ -30,11 +30,11 @@
     </div>
 
     <!-- Tabela de Pacotes -->
-    <mat-table 
-        *ngIf="!loading && !error" 
-        [dataSource]="pacotes" 
+    <mat-table
+        *ngIf="!loading && !error"
+        [dataSource]="pacotes"
         class="pacotes-table mat-elevation-8">
-        
+
         <!-- Destinatário Column -->
         <ng-container matColumnDef="destinatario">
             <mat-header-cell *matHeaderCellDef>Destinatário</mat-header-cell>
@@ -81,11 +81,28 @@
         <ng-container matColumnDef="prioridade">
             <mat-header-cell *matHeaderCellDef>Prioridade</mat-header-cell>
             <mat-cell *matCellDef="let pacote">
-                <mat-chip 
+                <mat-chip
                     [style.background-color]="getPrioridadeColor(pacote.prioridade)"
                     [style.color]="'white'">
                     {{ getPrioridadeText(pacote.prioridade) }}
                 </mat-chip>
+            </mat-cell>
+        </ng-container>
+
+        <!-- Ações Column -->
+        <ng-container matColumnDef="acoes">
+            <mat-header-cell *matHeaderCellDef>Ações</mat-header-cell>
+            <mat-cell *matCellDef="let pacote" class="acoes-cell">
+                <button
+                    mat-icon-button
+                    color="warn"
+                    (click)="apagarPacote(pacote)"
+                    [disabled]="isDeletingPacote(pacote.id)"
+                    [title]="isDeletingPacote(pacote.id) ? 'Apagando...' : 'Apagar pacote'"
+                    class="delete-btn">
+                    <mat-icon *ngIf="!isDeletingPacote(pacote.id)">delete</mat-icon>
+                    <mat-icon *ngIf="isDeletingPacote(pacote.id)" class="loading-icon">hourglass_empty</mat-icon>
+                </button>
             </mat-cell>
         </ng-container>
 

--- a/frontend/Entregou/src/app/user-dashboard/listar-pacote/listar-pacote.component.scss
+++ b/frontend/Entregou/src/app/user-dashboard/listar-pacote/listar-pacote.component.scss
@@ -46,8 +46,53 @@
 
         mat-header-cell {
             font-size: calc($font-default + 2px);
-            
+
             color: $text;
         }
+
+        .acoes-cell {
+            width: 80px;
+            text-align: center;
+
+            .delete-btn {
+                transition: all 0.2s ease;
+
+                &:hover:not(:disabled) {
+                    background-color: rgba(244, 67, 54, 0.1);
+                    transform: scale(1.1);
+                }
+
+                &:disabled {
+                    opacity: 0.5;
+                }
+
+                .loading-icon {
+                    animation: spin 1s linear infinite;
+                }
+            }
+        }
+    }
+}
+
+// Animation for loading icon
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+// Snackbar styles
+:host ::ng-deep {
+    .success-snackbar {
+        background-color: #4caf50 !important;
+        color: white !important;
+    }
+
+    .error-snackbar {
+        background-color: #f44336 !important;
+        color: white !important;
     }
 }

--- a/frontend/Entregou/src/app/user-dashboard/listar-pacote/listar-pacote.component.scss
+++ b/frontend/Entregou/src/app/user-dashboard/listar-pacote/listar-pacote.component.scss
@@ -46,7 +46,6 @@
 
         mat-header-cell {
             font-size: calc($font-default + 2px);
-
             color: $text;
         }
 
@@ -64,6 +63,7 @@
 
                 &:disabled {
                     opacity: 0.5;
+                    cursor: not-allowed;
                 }
 
                 .loading-icon {
@@ -94,5 +94,33 @@
     .error-snackbar {
         background-color: #f44336 !important;
         color: white !important;
+    }
+
+    // Estilos personalizados para o modal
+    .custom-dialog-container {
+        .mat-mdc-dialog-container {
+            .mdc-dialog__surface {
+                border-radius: 16px;
+                box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
+                overflow: hidden;
+
+                .mat-mdc-dialog-content {
+                    padding: 0;
+                    max-height: none;
+                }
+
+                .mat-mdc-dialog-actions {
+                    padding: 0;
+                    margin: 0;
+                    min-height: auto;
+                }
+            }
+        }
+    }
+
+    // Backdrop mais escuro
+    .cdk-overlay-backdrop {
+        background-color: rgba(0, 0, 0, 0.6) !important;
+        backdrop-filter: blur(2px);
     }
 }

--- a/frontend/Entregou/src/app/user-dashboard/listar-pacote/listar-pacote.component.ts
+++ b/frontend/Entregou/src/app/user-dashboard/listar-pacote/listar-pacote.component.ts
@@ -5,7 +5,9 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { DatabaseService } from '../../services/database.service';
+import { ModalConfirmacaoComponent, ConfirmDeleteData } from '../modal-confirmacao/modal-confirmacao.component';
 
 export interface Pacote {
   id: number;
@@ -29,7 +31,8 @@ export interface Pacote {
     MatIconModule,
     MatButtonModule,
     MatChipsModule,
-    MatSnackBarModule
+    MatSnackBarModule,
+    MatDialogModule
   ],
   templateUrl: './listar-pacote.component.html',
   styleUrls: ['./listar-pacote.component.scss']
@@ -60,7 +63,8 @@ export class ListarPacoteComponent implements OnInit {
 
   constructor(
     private databaseService: DatabaseService,
-    private snackBar: MatSnackBar
+    private snackBar: MatSnackBar,
+    private dialog: MatDialog
   ) {}
 
   ngOnInit(): void {
@@ -138,32 +142,52 @@ export class ListarPacoteComponent implements OnInit {
       return;
     }
 
-    if (confirm(`Tem certeza que deseja apagar o pacote para ${pacote.destinatario}?`)) {
-      this._deleting.set(pacote.id);
+    // Configura os dados do modal
+    const dialogData: ConfirmDeleteData = {
+      destinatario: pacote.destinatario,
+      titulo: 'Confirmar Exclusão do Pacote',
+      mensagem: 'Tem certeza que deseja apagar o pacote para:'
+    };
 
-      this.databaseService.apagarPacote(pacote.id).subscribe({
-        next: () => {
-          // Remove o pacote da lista local
-          const pacotesAtuais = this._pacotes();
-          const novosPacotes = pacotesAtuais.filter(p => p.id !== pacote.id);
-          this._pacotes.set(novosPacotes);
+    // Abre o modal de confirmação
+    const dialogRef = this.dialog.open(ModalConfirmacaoComponent, {
+      data: dialogData,
+      disableClose: true,
+      autoFocus: false,
+      restoreFocus: false,
+      width: '450px',
+      panelClass: ['custom-dialog-container']
+    });
 
-          this.snackBar.open('Pacote apagado com sucesso!', 'Fechar', {
-            duration: 3000,
-            panelClass: ['success-snackbar']
-          });
-          this._deleting.set(null);
-        },
-        error: (error) => {
-          console.error('Erro ao apagar pacote:', error);
-          this.snackBar.open('Erro ao apagar pacote. Tente novamente.', 'Fechar', {
-            duration: 3000,
-            panelClass: ['error-snackbar']
-          });
-          this._deleting.set(null);
-        }
-      });
-    }
+    // Processa o resultado do modal
+    dialogRef.afterClosed().subscribe(confirmed => {
+      if (confirmed && pacote.id) {
+        this._deleting.set(pacote.id);
+
+        this.databaseService.apagarPacote(pacote.id).subscribe({
+          next: () => {
+            // Remove o pacote da lista local
+            const pacotesAtuais = this._pacotes();
+            const novosPacotes = pacotesAtuais.filter(p => p.id !== pacote.id);
+            this._pacotes.set(novosPacotes);
+
+            this.snackBar.open('Pacote apagado com sucesso!', 'Fechar', {
+              duration: 3000,
+              panelClass: ['success-snackbar']
+            });
+            this._deleting.set(null);
+          },
+          error: (error) => {
+            console.error('Erro ao apagar pacote:', error);
+            this.snackBar.open('Erro ao apagar pacote. Tente novamente.', 'Fechar', {
+              duration: 3000,
+              panelClass: ['error-snackbar']
+            });
+            this._deleting.set(null);
+          }
+        });
+      }
+    });
   }
 
   isDeletingPacote(id?: number): boolean {

--- a/frontend/Entregou/src/app/user-dashboard/listar-pacote/listar-pacote.component.ts
+++ b/frontend/Entregou/src/app/user-dashboard/listar-pacote/listar-pacote.component.ts
@@ -4,10 +4,11 @@ import { MatTableModule } from '@angular/material/table';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { DatabaseService } from '../../services/database.service';
 
 export interface Pacote {
-  id?: number;
+  id: number;
   destinatario: string;
   remetente: string;
   tipoPacote: string;
@@ -27,7 +28,8 @@ export interface Pacote {
     MatTableModule,
     MatIconModule,
     MatButtonModule,
-    MatChipsModule
+    MatChipsModule,
+    MatSnackBarModule
   ],
   templateUrl: './listar-pacote.component.html',
   styleUrls: ['./listar-pacote.component.scss']
@@ -37,6 +39,7 @@ export class ListarPacoteComponent implements OnInit {
   private _pacotes = signal<Pacote[]>([]);
   private _loading = signal<boolean>(false);
   private _error = signal<string | null>(null);
+  private _deleting = signal<number | null>(null);
 
   // Getter para usar no template (converte Signal para Array)
   get pacotes(): Pacote[] {
@@ -51,7 +54,14 @@ export class ListarPacoteComponent implements OnInit {
     return this._error();
   }
 
-  constructor(private databaseService: DatabaseService) {}
+  get deleting(): number | null {
+    return this._deleting();
+  }
+
+  constructor(
+    private databaseService: DatabaseService,
+    private snackBar: MatSnackBar
+  ) {}
 
   ngOnInit(): void {
     this.carregarPacotes();
@@ -82,6 +92,7 @@ export class ListarPacoteComponent implements OnInit {
     'codigoRastreio',
     'descricaoConteudo',
     'prioridade',
+    'acoes'
   ];
 
   // Método para recarregar os dados
@@ -116,5 +127,46 @@ export class ListarPacoteComponent implements OnInit {
       case 'cancelado': return 'Cancelado';
       default: return 'N/A';
     }
+  }
+
+  apagarPacote(pacote: Pacote): void {
+    if (!pacote.id) {
+      this.snackBar.open('Erro: ID do pacote não encontrado', 'Fechar', {
+        duration: 3000,
+        panelClass: ['error-snackbar']
+      });
+      return;
+    }
+
+    if (confirm(`Tem certeza que deseja apagar o pacote para ${pacote.destinatario}?`)) {
+      this._deleting.set(pacote.id);
+
+      this.databaseService.apagarPacote(pacote.id).subscribe({
+        next: () => {
+          // Remove o pacote da lista local
+          const pacotesAtuais = this._pacotes();
+          const novosPacotes = pacotesAtuais.filter(p => p.id !== pacote.id);
+          this._pacotes.set(novosPacotes);
+
+          this.snackBar.open('Pacote apagado com sucesso!', 'Fechar', {
+            duration: 3000,
+            panelClass: ['success-snackbar']
+          });
+          this._deleting.set(null);
+        },
+        error: (error) => {
+          console.error('Erro ao apagar pacote:', error);
+          this.snackBar.open('Erro ao apagar pacote. Tente novamente.', 'Fechar', {
+            duration: 3000,
+            panelClass: ['error-snackbar']
+          });
+          this._deleting.set(null);
+        }
+      });
+    }
+  }
+
+  isDeletingPacote(id?: number): boolean {
+    return this.deleting === id;
   }
 }

--- a/frontend/Entregou/src/app/user-dashboard/modal-confirmacao/modal-confirmacao.component.html
+++ b/frontend/Entregou/src/app/user-dashboard/modal-confirmacao/modal-confirmacao.component.html
@@ -1,0 +1,29 @@
+<div class="dialog-container">
+  <div class="dialog-header">
+    <mat-icon class="warning-icon">warning</mat-icon>
+    <h2 mat-dialog-title>{{ data.titulo || 'Confirmar Exclusão' }}</h2>
+  </div>
+
+  <div mat-dialog-content class="dialog-content">
+    <p>{{ data.mensagem || 'Tem certeza que deseja apagar o pacote para:' }}</p>
+    <p class="destinatario-name">{{ data.destinatario }}</p>
+    <p class="warning-text">Esta ação não pode ser desfeita.</p>
+  </div>
+
+  <div mat-dialog-actions class="dialog-actions">
+    <button
+      mat-button
+      (click)="onCancel()"
+      class="cancel-btn">
+      Cancelar
+    </button>
+    <button
+      mat-raised-button
+      color="warn"
+      (click)="onConfirm()"
+      class="delete-btn">
+      <mat-icon>delete</mat-icon>
+      Apagar
+    </button>
+  </div>
+</div>

--- a/frontend/Entregou/src/app/user-dashboard/modal-confirmacao/modal-confirmacao.component.scss
+++ b/frontend/Entregou/src/app/user-dashboard/modal-confirmacao/modal-confirmacao.component.scss
@@ -1,0 +1,112 @@
+.dialog-container {
+  min-width: 400px;
+  max-width: 500px;
+  padding: 4px;
+}
+
+.dialog-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 16px 16px 0;
+
+  .warning-icon {
+    color: #ff9800;
+    font-size: 32px;
+    width: 32px;
+    height: 32px;
+  }
+
+  h2 {
+    margin: 0;
+    color: #333;
+    font-weight: 600;
+  }
+}
+
+.dialog-content {
+  padding: 0 16px 16px;
+
+  p {
+    margin: 8px 0;
+    color: #666;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  .destinatario-name {
+    font-weight: 600;
+    color: #333;
+    font-size: 16px;
+    background-color: #f5f5f5;
+    padding: 12px 16px;
+    border-radius: 8px;
+    border-left: 4px solid #2196f3;
+    margin: 16px 0;
+  }
+
+  .warning-text {
+    font-size: 13px;
+    color: #f44336;
+    font-style: italic;
+    margin-top: 16px;
+    text-align: center;
+  }
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 16px;
+  margin: 0;
+
+  .cancel-btn {
+    color: #666;
+    font-weight: 500;
+    padding: 0 24px;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.04);
+    }
+  }
+
+  .delete-btn {
+    background-color: #f44336;
+    color: white;
+    font-weight: 600;
+    padding: 0 24px;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background-color: #d32f2f;
+      transform: translateY(-1px);
+      box-shadow: 0 4px 8px rgba(244, 67, 54, 0.3);
+    }
+
+    mat-icon {
+      margin-right: 8px;
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+    }
+  }
+}
+
+// Animação de entrada
+:host {
+  animation: slideInModal 0.3s ease-out;
+}
+
+@keyframes slideInModal {
+  0% {
+    opacity: 0;
+    transform: scale(0.9) translateY(-20px);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}

--- a/frontend/Entregou/src/app/user-dashboard/modal-confirmacao/modal-confirmacao.component.spec.ts
+++ b/frontend/Entregou/src/app/user-dashboard/modal-confirmacao/modal-confirmacao.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ModalConfirmacaoComponent } from './modal-confirmacao.component';
+
+describe('ModalConfirmacaoComponent', () => {
+  let component: ModalConfirmacaoComponent;
+  let fixture: ComponentFixture<ModalConfirmacaoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ModalConfirmacaoComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ModalConfirmacaoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/Entregou/src/app/user-dashboard/modal-confirmacao/modal-confirmacao.component.ts
+++ b/frontend/Entregou/src/app/user-dashboard/modal-confirmacao/modal-confirmacao.component.ts
@@ -1,0 +1,33 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+
+export interface ConfirmDeleteData {
+  destinatario: string;
+  titulo?: string;
+  mensagem?: string;
+}
+
+@Component({
+  selector: 'app-modal-confirmacao',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule, MatIconModule],
+  templateUrl: './modal-confirmacao.component.html',
+  styleUrl: './modal-confirmacao.component.scss'
+})
+export class ModalConfirmacaoComponent {
+  constructor(
+    public dialogRef: MatDialogRef<ModalConfirmacaoComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: ConfirmDeleteData
+  ) {}
+
+  onCancel(): void {
+    this.dialogRef.close(false);
+  }
+
+  onConfirm(): void {
+    this.dialogRef.close(true);
+  }
+}


### PR DESCRIPTION
Este pull request adiciona um recurso amigável para exclusão de pacotes ("pacotes") no painel do usuário, incluindo um modal de confirmação e melhor feedback ao usuário.  Aprimora a UI/UX da ação de exclusão. As principais mudanças estão agrupadas abaixo:

### Recurso: Exclusão de Pacotes com Confirmação

* Adicionado novo método `apagarPacote` em `DatabaseService` para suportar a exclusão de pacotes no backend via requisição HTTP DELETE.
* Implementada a ação de exclusão na lista de pacotes: adicionada uma coluna "Ações" com botão de excluir, que aciona um modal de confirmação antes da exclusão. A interface mostra feedback de carregamento e desabilita o botão durante a operação.
* Criado um novo `ModalConfirmacaoComponent` independente para o diálogo de confirmação, incluindo HTML, TypeScript, SCSS e um teste básico.

### Melhorias de UI/UX

* Estilos aprimorados para o botão de exclusão, modal de confirmação e notificações (snackbar) de sucesso e erro em `listar-pacote.component.scss`. Adicionada animação de carregamento e melhor aparência do modal.
* Atualizada a lista de pacotes para incluir a nova coluna de ações e melhorar o feedback ao usuário (mensagens de snackbar, estado de carregamento e modal de confirmação).
